### PR TITLE
Lower the drop chance for epic and legendary loot

### DIFF
--- a/LootTables_Nugget.xml
+++ b/LootTables_Nugget.xml
@@ -4,19 +4,19 @@
 	<loottable name="NuggetSmall">
 		<rewardLevel min="0" max="3">
 			<advisors chance="0.10">
-				<rarity  common="0.45" uncommon="0.30" rare="0.25" epic="0.00" />
+				<rarity  common="0.50" uncommon="0.40" rare="0.10" epic="0.00" />
 			</advisors>
 			<materials chance="0.25">
-				<rarity junk="0.30" uncommon="0.30" common="0.25" rare="0.15" epic="0.00" />
+				<rarity junk="0.40" common="0.20" uncommon="0.40" rare="0.00" epic="0.00" />
 			</materials>
 			<consumables chance="0.25">
-				<rarity  common="0.45" uncommon="0.30" rare="0.25" epic="0.00" />
+				<rarity  common="0.50" uncommon="0.40" rare="0.10" epic="0.00" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity  common="0.45" uncommon="0.30" rare="0.25" epic="0.00" />
+				<rarity  common="0.50" uncommon="0.40" rare="0.10" epic="0.00" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity  common="0.45" uncommon="0.30" rare="0.25" epic="0.00" />
+				<rarity  common="0.50" uncommon="0.40" rare="0.10" epic="0.00" />
 			</blueprints>
 			<traits chance="0.20">
 				<rarity uncommon="0.65" rare="0.30" epic="0.05" legendary="0.00" />
@@ -24,108 +24,108 @@
 		</rewardLevel>
 		<rewardLevel min="4" max="99">
 			<advisors chance="0.10">
-				<rarity  common="0.40" uncommon="0.30" rare="0.25" epic="0.05" />
+				<rarity  common="0.43" uncommon="0.40" rare="0.15" epic="0.02" />
 			</advisors>
 			<materials chance="0.25">
-				<rarity junk="0.25" uncommon="0.30" common="0.25" rare="0.15" epic="0.05" />
+				<rarity junk="0.28" common="0.25" uncommon="0.40" rare="0.05" epic="0.02" />
 			</materials>
 			<consumables chance="0.25">
-				<rarity  common="0.40" uncommon="0.30" rare="0.25" epic="0.05" />
+				<rarity  common="0.43" uncommon="0.40" rare="0.15" epic="0.02" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity  common="0.40" uncommon="0.30" rare="0.25" epic="0.05" />
+				<rarity  common="0.43" uncommon="0.40" rare="0.15" epic="0.02" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity  common="0.40" uncommon="0.30" rare="0.25" epic="0.05" />
+				<rarity  common="0.43" uncommon="0.40" rare="0.15" epic="0.02" />
 			</blueprints>
 			<traits chance="0.20">
-				<rarity uncommon="0.60" rare="0.30" epic="0.10" legendary="0.00" />
+				<rarity uncommon="0.65" rare="0.30" epic="0.05" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="NuggetMedium">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.45" rare="0.20" epic="0.05" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.25" uncommon="0.45" rare="0.20" epic="0.05" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.45" rare="0.20" epic="0.05" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.45" rare="0.20" epic="0.05" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.45" rare="0.20" epic="0.05" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.50" rare="0.40" epic="0.10" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="NuggetLarge">
 		<rewardLevel min="0" max="42">
 			<advisors chance="0.15">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</advisors>
 			<materials chance="0.10">
-				<rarity junk="0.05" common="0.10" uncommon="0.20" rare="0.40" epic="0.25" />
+				<rarity junk="0.15" common="0.15" uncommon="0.35" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</blueprints>
 			<traits chance="0.45">
-				<rarity uncommon="0.15" rare="0.50" epic="0.35" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 		<rewardLevel min="43" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</advisors>
 			<materials chance="0.10">
-				<rarity junk="0.05" common="0.10" uncommon="0.20" rare="0.40" epic="0.25" />
+				<rarity junk="0.15" common="0.15" uncommon="0.35" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity common="0.10" uncommon="0.20" rare="0.45" epic="0.25" />
+				<rarity common="0.25" uncommon="0.35" rare="0.30" epic="0.10" />
 			</blueprints>
 			<traits chance="0.45">
-				<rarity uncommon="0.15" rare="0.49" epic="0.35" legendary="0.01" />
+				<rarity uncommon="0.44" rare="0.40" epic="0.15" legendary="0.01" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="NuggetLegendary">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.20">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.40" rare="0.40" epic="0.15" />
 			</advisors>
 			<materials chance="0.05">
-				<rarity junk="0.01" common="0.04" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity junk="0.01" common="0.04" uncommon="0.40" rare="0.40" epic="0.15" />
 			</materials>
 			<consumables chance="0.05">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.40" rare="0.40" epic="0.15" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.40" rare="0.40" epic="0.15" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.40" rare="0.40" epic="0.15" />
 			</blueprints>
 			<traits chance="0.50">
-				<rarity uncommon="0.05" rare="0.35" epic="0.50" legendary="0.10" />
+				<rarity uncommon="0.37" rare="0.35" epic="0.25" legendary="0.03" />
 			</traits>
 		</rewardLevel>
 	</loottable>

--- a/LootTables_Quest.xml
+++ b/LootTables_Quest.xml
@@ -4,148 +4,148 @@
 	<loottable name="General">
 		<rewardLevel min="0" max="42">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 		<rewardLevel min="43" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.39" rare="0.40" epic="0.20" legendary="0.01" />
+				<rarity uncommon="0.44" rare="0.40" epic="0.15" legendary="0.01" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="GeneralLegendary">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.20">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.25" rare="0.45" epic="0.25" />
 			</advisors>
 			<materials chance="0.05">
-				<rarity junk="0.01" common="0.04" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity junk="0.01" common="0.14" uncommon="0.15" rare="0.45" epic="0.25" />
 			</materials>
 			<consumables chance="0.05">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.25" rare="0.45" epic="0.25" />
 			</consumables>
 			<designs chance="0.10">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.25" rare="0.45" epic="0.25" />
 			</designs>
 			<blueprints chance="0.10">
-				<rarity common="0.05" uncommon="0.15" rare="0.45" epic="0.35" />
+				<rarity common="0.05" uncommon="0.25" rare="0.45" epic="0.25" />
 			</blueprints>
 			<traits chance="0.50">
-				<rarity uncommon="0.05" rare="0.35" epic="0.50" legendary="0.10" />
+				<rarity uncommon="0.22" rare="0.35" epic="0.40" legendary="0.03" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="GeneralSkirmish">
 		<rewardLevel min="0" max="42">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 		<rewardLevel min="43" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.39" rare="0.40" epic="0.20" legendary="0.01" />
+				<rarity uncommon="0.44" rare="0.40" epic="0.15" legendary="0.01" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="GeneralCampaign">
 		<rewardLevel min="0" max="42">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 		<rewardLevel min="43" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.39" rare="0.40" epic="0.20" legendary="0.01" />
+				<rarity uncommon="0.44" rare="0.40" epic="0.15" legendary="0.01" />
 			</traits>
 		</rewardLevel>
 	</loottable>
@@ -196,130 +196,130 @@
 	<loottable name="Weekly">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.25">
-				<rarity common="0.05" uncommon="0.15" rare="0.35" epic="0.45" />
+				<rarity common="0.05" uncommon="0.25" rare="0.35" epic="0.35" />
 			</advisors>
 			<materials chance="0.05">
-				<rarity junk="0.01" common="0.04" uncommon="0.15" rare="0.35" epic="0.45" />
+				<rarity junk="0.01" common="0.14" uncommon="0.15" rare="0.35" epic="0.35" />
 			</materials>
 			<consumables chance="0.05">
-				<rarity common="0.05" uncommon="0.15" rare="0.35" epic="0.45" />
+				<rarity common="0.05" uncommon="0.25" rare="0.35" epic="0.35" />
 			</consumables>
 			<designs chance="0.05">
-				<rarity common="0.05" uncommon="0.15" rare="0.35" epic="0.45" />
+				<rarity common="0.05" uncommon="0.25" rare="0.35" epic="0.35" />
 			</designs>
 			<blueprints chance="0.05">
-				<rarity common="0.05" uncommon="0.15" rare="0.35" epic="0.45" />
+				<rarity common="0.05" uncommon="0.25" rare="0.35" epic="0.35" />
 			</blueprints>
 			<traits chance="0.55">
-				<rarity uncommon="0.05" rare="0.25" epic="0.50" legendary="0.20" />
+				<rarity uncommon="0.25" rare="0.30" epic="0.40" legendary="0.05" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="Booster1">
 		<rewardLevel min="0" max="42">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 		<rewardLevel min="43" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.39" rare="0.40" epic="0.20" legendary="0.01" />
+				<rarity uncommon="0.44" rare="0.40" epic="0.15" legendary="0.01" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="CeltWarrior">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="CeltDruid">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 	</loottable>
 	<loottable name="CeltHigh">
 		<rewardLevel min="0" max="99">
 			<advisors chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</advisors>
 			<materials chance="0.15">
-				<rarity junk="0.05" common="0.25" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity junk="0.05" common="0.30" uncommon="0.30" rare="0.25" epic="0.10" />
 			</materials>
 			<consumables chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</consumables>
 			<designs chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</designs>
 			<blueprints chance="0.15">
-				<rarity common="0.30" uncommon="0.30" rare="0.25" epic="0.15" />
+				<rarity common="0.30" uncommon="0.35" rare="0.25" epic="0.10" />
 			</blueprints>
 			<traits chance="0.25">
-				<rarity uncommon="0.40" rare="0.40" epic="0.20" legendary="0.00" />
+				<rarity uncommon="0.45" rare="0.40" epic="0.15" legendary="0.00" />
 			</traits>
 		</rewardLevel>
 	</loottable>


### PR DESCRIPTION
Okay, so here is my first suggestion for the updated loot table. It may seem a bit harsh to cut the chance of legendary loot to about a third of it right now, but prices show that they are way to common right now. I want to lower them to keep people motivated to play the game. 
We may need to alter it again, when camps give more than only one chest.